### PR TITLE
Fix issue #46

### DIFF
--- a/meningotype/meningotype.py
+++ b/meningotype/meningotype.py
@@ -96,7 +96,7 @@ def check_fasta(f):
             line = line.strip()
             if not line or line[0] == '>':
                 continue
-            if bool(re.search('[^ACTGactgNn-]', line)):
+            if bool(re.search('[^ACTGactgNnWwYyRrKkMmSsDdBbHhVv-]', line)):
                 return False
     return True
 


### PR DESCRIPTION
Added all possible nucleotide characters in the check_fasta function.

Otherwise the software would fail to run on genomes that contained even at-least 1 non-canonical character (i.e. W, Y).