### PR TITLE
remove usage of pkg_resources

### DIFF
--- a/meningotype/ctrA.py
+++ b/meningotype/ctrA.py
@@ -14,7 +14,7 @@ from subprocess import Popen, PIPE
 from io import StringIO
 from Bio import SeqIO
 from Bio.Blast.Applications import NcbiblastnCommandline
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 # Standard functions
 # Log a message to stderr
@@ -88,7 +88,7 @@ def main():
 				        )
     args = parser.parse_args()
 
-    DBpath = resource_filename(__name__, 'db')
+    DBpath = str(files(__package__).joinpath('db'))
 
     # Main
     print('\t'.join(['SAMPLE_ID', 'PCRresult', 'BLASTresult']))

--- a/meningotype/finetype.py
+++ b/meningotype/finetype.py
@@ -13,7 +13,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Blast.Applications import NcbiblastnCommandline
 from Bio.Blast import NCBIXML
-from pkg_resources import resource_string, resource_filename
+from importlib.resources import files
 
 # Import local modules
 from . import nmen
@@ -94,7 +94,7 @@ def main():
 	if args.db:
 		DBpath = str(args.db).rstrip('/')
 	else:
-		DBpath = resource_filename(__name__, 'db')
+		DBpath = str(files(__package__).joinpath('db'))
 
 	porBDB = os.path.join( DBpath, 'blast', 'porB' )
 

--- a/meningotype/meningotype.py
+++ b/meningotype/meningotype.py
@@ -16,7 +16,7 @@ from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Blast.Applications import NcbiblastnCommandline, NcbiblastxCommandline
-from pkg_resources import resource_filename
+from importlib.resources import files
 from io import StringIO
 from . import run_subprocess as rs
 from . import menwy, ctrA, finetype, check_deps
@@ -377,7 +377,7 @@ def main():
     if args.db:
         DBpath = str(args.db).rstrip('/')
     else:
-        DBpath = resource_filename(__name__, 'db')
+        DBpath = str(files(__package__).joinpath('db'))
 
     # Path to database files
     porA1alleles = os.path.join( DBpath, 'PorA_VR1.fas' )
@@ -481,7 +481,7 @@ def main():
 
     # Test example to check meningotype works
     if args.test:
-        TESTpath = resource_filename(__name__, 'test')
+        TESTpath = str(files(__package__).joinpath('test'))
         testSEQS = [os.path.join( TESTpath, f ) for f in ['A.fna', 'B.fna', 'C.fna', 'W.fna', 'X.fna', 'Y.fna'] ]
         msg('\033[94mRunning meningotype.py on test examples ... \033[0m')
         msg('$ meningotype.py A.fna B.fna C.fna W.fna X.fna Y.fna')

--- a/meningotype/menwy.py
+++ b/meningotype/menwy.py
@@ -14,7 +14,7 @@ from Bio.Seq import Seq
 from Bio import SeqIO
 from Bio.Blast.Applications import NcbiblastnCommandline
 from Bio.Blast import NCBIXML
-from pkg_resources import resource_string, resource_filename
+from importlib.resources import files
 
 # Local modules
 from . import nmen
@@ -22,7 +22,7 @@ from . import nmen
 # BLAST
 def seqBLAST(f):
 	# Set globals
-	DBpath = resource_filename(__name__, 'db')
+	DBpath = str(files(__package__).joinpath('db'))
 	blastdb = os.path.join(DBpath, 'blast', 'synG')
 	# BLAST
 	fBLAST = NcbiblastnCommandline(query=f, db=blastdb, outfmt="6 qseqid sstrand qstart qend sstart send slen qseq", dust='no', culling_limit=1)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(name='meningotype',
 	classifiers=[
 		'Development Status :: 4 - Beta',
 		'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
 		'Programming Language :: Python :: 3.8',
 		'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
`setuptools` is no longer installed by default with python.

Might as well transition to use native python libs.

Tested locally.