### PR TITLE
Python3 migration fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - mlst
   - blast
   - isPcr
+  - perl-list-moreutils

--- a/meningotype/ctrA.py
+++ b/meningotype/ctrA.py
@@ -38,21 +38,19 @@ def ctrA_PCR(f, p, dbpath):
     proc = Popen(['isPcr', f, ctrAPRIMERS, 'stdout', '-minPerfect=10'], stdout=PIPE, stderr=PIPE)
     PCRout = proc.communicate()[0].decode('UTF-8')
     if not PCRout:
-        ctrABLAST = NcbiblastnCommandline(
+        stdout, stderr = run_blast.seqBLAST(
         	query=f,
         	db=ctrADB,
-        	task='blastn',
+        	blast='blastn',
         	perc_identity=90,
         	evalue='1e-20',
-        	outfmt='"6 sseqid pident length"',
-        	culling_limit='1')
+        	outfmt='6 sseqid pident length',
+        	culling_limit=1)
 
-        stdout, stderr = ctrABLAST()
-        # msg(stdout)
         if stdout:
             line = stdout.split('\n')[0]
             amp = line.split('\t')
-            resultBLAST = amp[1] # Currently only takes top/first BLAST hit
+            resultBLAST = amp[0] # Currently only takes top/first BLAST hit
     else:
         alleleSEQ = StringIO()
         alleleSEQ.write(PCRout)

--- a/meningotype/finetype.py
+++ b/meningotype/finetype.py
@@ -36,7 +36,7 @@ def porBBLAST(f, blastdb, cpus):
 	porBRECR = None
 	# fBLAST = NcbiblastnCommandline(query=f, db=blastdb, outfmt="'6 qseqid sseqid pident length sstrand qstart qend sstart send slen'", dust='no', culling_limit=1, num_threads=cpus)
 	
-	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt="'6 qseqid sseqid pident length sstrand qstart qend sstart send slen'", perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
+	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt="6 qseqid sseqid pident length sstrand qstart qend sstart send slen", perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
 	blastOUT = stdout.split('\t')
 	# msg(blastOUT)
 	if len(blastOUT) == 10:

--- a/meningotype/meningotype.py
+++ b/meningotype/meningotype.py
@@ -18,6 +18,8 @@ import os.path
 import re
 from io import StringIO
 import urllib
+import urllib.request
+from urllib.error import HTTPError
 import subprocess
 from subprocess import Popen, PIPE
 from Bio import SeqIO
@@ -89,7 +91,7 @@ def err(*args, **kwargs):
 def update_db(db_file, db_url):
 	if os.path.isfile(db_file):
 		os.rename(db_file, db_file+'.old')
-	urllib.urlretrieve(db_url, db_file)
+	urllib.request.urlretrieve(db_url, db_file)
 
 # Check files are present
 def check_primer_files(f):

--- a/meningotype/meningotype.py
+++ b/meningotype/meningotype.py
@@ -135,7 +135,7 @@ def seroTYPE(f, seroprimers, allelesdb, cpus):
 		sero = None
 		# seroBLAST = NcbiblastnCommandline(query=f, db=allelesdb, task='blastn', perc_identity=90, evalue='1e-20', outfmt='"6 sseqid pident length"', culling_limit='1', num_threads=cpus)
 		# seroBLAST = 
-		stdout, stderr = run_blast.seqBLAST(query=f, db=allelesdb, blast='blastn', outfmt='"6 sseqid pident length"', perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
+		stdout, stderr = run_blast.seqBLAST(query=f, db=allelesdb, blast='blastn', outfmt="6 sseqid pident length", perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
 		lenMATCH = 0
 		line = stdout.split('\n')[0]
 		amp = line.split('\t')
@@ -181,7 +181,7 @@ def finetypeBLAST(s, db, cpus):
 	allele = None
 	# ftBLAST = NcbiblastxCommandline(query='-', db=db, outfmt='"6 qseqid sseqid pident length slen gaps nident evalue"', seg='no', query_gencode='11', matrix='PAM30', ungapped='true', comp_based_stats='0', evalue='1e-2', num_threads=cpus)		# blastx command to fix finding short sequences
 	# ftBLAST = 
-	stdout, stderr = run_blast.seqBLAST(query='-', db=db, blast='blastx', outfmt='"6 qseqid sseqid pident length slen gaps nident evalue"', seg='no', query_gencode='11', matrix='PAM30', ungapped='true', comp_based_stats='0', evalue='1e-2', num_threads=cpus, fasta_data=str(s.format('fasta')))
+	stdout, stderr = run_blast.seqBLAST(query='-', db=db, blast='blastx', outfmt="6 qseqid sseqid pident length slen gaps nident evalue", evalue='1e-2', num_threads=cpus, fasta_data=str(s.format('fasta')), extra_flags=["-seg", "no", "-query_gencode", "11", "-matrix", "PAM30", "-ungapped", "-comp_based_stats", "0"])
 	if stdout:
 		BLASTout = stdout.split('\n')
 		lenMATCH = 0
@@ -209,7 +209,7 @@ def bxtypeBLAST(s, db, cpus):
 	allele = None
 	# bxBLAST = NcbiblastxCommandline(query='-', db=db, outfmt='"6 qseqid sseqid pident length slen gaps nident evalue"', seg='no', culling_limit='1', evalue='1e-100', query_gencode='11', num_threads=cpus)
 	
-	stdout, stderr = run_blast.seqBLAST(query='-', db=db, blast='blastx', outfmt='"6 qseqid sseqid pident length slen gaps nident evalue"', seg='no', culling_limit='1', evalue='1e-100', query_gencode='11', num_threads=cpus, fasta_data=str(s.format('fasta')))
+	stdout, stderr = run_blast.seqBLAST(query='-', db=db, blast='blastx', outfmt="6 qseqid sseqid pident length slen gaps nident evalue", culling_limit=1, evalue='1e-100', num_threads=cpus, fasta_data=str(s.format('fasta')), extra_flags=["-seg", "no", "-query_gencode", "11"])
 	if stdout:
 		BLASTout = stdout.split('\n')
 		lenMATCH = 0
@@ -259,7 +259,7 @@ def fineTYPE(f, finetypeprimers, poradb, pora1db, pora2db, fetdb, cpus):
 	if len(porACOUNT) == 0:
 		# porseqBLAST = NcbiblastnCommandline(query=f, db=poradb, perc_identity=90, outfmt='"6 qseq"', culling_limit='1', num_threads=cpus)
 		
-		stdout, stderr = run_blast.seqBLAST(query=f, db=poradb, blast='blastn', outfmt='"6 qseq"', perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
+		stdout, stderr = run_blast.seqBLAST(query=f, db=poradb, blast='blastn', outfmt="6 qseq", perc_identity=90, evalue='1e-20', num_threads=cpus, culling_limit=1)
 		if stdout:
 			porAseq = Seq(stdout.strip())
 			porArec = SeqRecord(porAseq, id=f, description='PorA')

--- a/meningotype/meningotype.py
+++ b/meningotype/meningotype.py
@@ -127,7 +127,7 @@ def makeblastDB(db, infile, dbtype):
 def seroTYPE(f, seroprimers, allelesdb, cpus):
 	seroCOUNT = []				# Setup list in case there are mixed/multiple hits
 	proc = subprocess.Popen(['isPcr', f, seroprimers, 'stdout', '-minPerfect=10'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	PCRout = f"{proc.communicate()[0].decode('utf-8')}"
+	PCRout = proc.communicate()[0].decode('utf-8')
 	
 	if not PCRout:
 		sero = None
@@ -171,7 +171,7 @@ def seroWY(f, sero):
 
 def nm_mlst(f):
 	proc = subprocess.Popen(['mlst', '--scheme=neisseria', '--quiet', f], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	PCRout = proc.communicate()[0]
+	PCRout = proc.communicate()[0].decode('utf-8')
 	return PCRout.split('\t')[2]
 
 def finetypeBLAST(s, db, cpus):
@@ -232,7 +232,7 @@ def fineTYPE(f, finetypeprimers, poradb, pora1db, pora2db, fetdb, cpus):
 	global porASEQS
 	global fetASEQS
 	proc = subprocess.Popen(['isPcr', f, finetypeprimers, 'stdout', '-maxSize=800', '-tileSize=10', '-minPerfect=8', '-stepSize=3'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-	PCRout = proc.communicate()[0]
+	PCRout = proc.communicate()[0].decode('utf-8')
 	alleleSEQ = StringIO()
 	alleleSEQ.write(PCRout)
 	alleleSEQ.seek(0)
@@ -282,7 +282,7 @@ def bxTYPE(f, bxPRIMERS, fHbpDB, NHBADB, NadADB, cpus):
 	global NHBASEQS
 	global NadASEQS
 	proc = subprocess.Popen(['isPcr', f, bxPRIMERS, 'stdout', '-maxSize=3000', '-tileSize=7', '-minPerfect=8', '-stepSize=3'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-	PCRout = proc.communicate()[0]
+	PCRout = proc.communicate()[0].decode('utf-8')
 	alleleSEQ = StringIO()
 	alleleSEQ.write(PCRout)
 	alleleSEQ.seek(0)

--- a/meningotype/menwy.py
+++ b/meningotype/menwy.py
@@ -26,7 +26,7 @@ def seqBLAST(f):
 	DBpath = os.path.join(os.path.dirname(__file__), 'db')
 	blastdb = os.path.join(DBpath, 'blast', 'synG')
 	
-	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt=f"6 qseqid sstrand qstart qend sstart send slen qseq", perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1)
+	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt="6 qseqid sstrand qstart qend sstart send slen qseq", perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1)
 
 	blastOUT = stdout.split('\t')
 	if len(blastOUT) == 8:

--- a/meningotype/porB.py
+++ b/meningotype/porB.py
@@ -40,7 +40,7 @@ def porBBLAST(f, blastdb):
 	porBRECR = None
 	# fBLAST = NcbiblastnCommandline(query=f, db=blastdb, outfmt="'6 qseqid sseqid pident length sstrand qstart qend sstart send slen'", dust='no', culling_limit=1)
 	# 
-	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt="'6 qseqid sseqid pident length sstrand qstart qend sstart send slen'", perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1)
+	stdout, stderr = run_blast.seqBLAST(query=f, db=blastdb, blast='blastn', outfmt="6 qseqid sseqid pident length sstrand qstart qend sstart send slen", perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1)
 	blastOUT = stdout.split('\t')
 	if len(blastOUT) == 10:
 		blast_qseqid = blastOUT[0]

--- a/meningotype/run_blast.py
+++ b/meningotype/run_blast.py
@@ -1,32 +1,35 @@
 import subprocess
 
 
-# NcbiblastnCommandline(query=f, db=allelesdb, task='blastn', perc_identity=90, evalue='1e-20', outfmt='"6 sseqid pident length"', culling_limit='1', num_threads=cpus)
-
-def seqBLAST(query, db, blast, outfmt, perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1, dust='no', fasta_data=None):
+def seqBLAST(query, db, blast, outfmt, perc_identity=90, evalue='1e-20', num_threads=1, culling_limit=1, dust=None, fasta_data=None, extra_flags=None):
     command = [
-			blast,
-			"-query", query,
-			"-db", db,
-			"-perc_identity", str(perc_identity),
-			"-evalue", evalue,
-			"-outfmt", outfmt,
-			"-culling_limit", str(culling_limit),
-			"-num_threads", str(num_threads)
-		]
+        blast,
+        "-query", query,
+        "-db", db,
+        "-evalue", evalue,
+        "-outfmt", outfmt,
+        "-culling_limit", str(culling_limit),
+        "-num_threads", str(num_threads)
+    ]
+    if blast == 'blastn':
+        command += ["-perc_identity", str(perc_identity)]
+        if dust is not None:
+            command += ["-dust", dust]
+    if extra_flags:
+        command += extra_flags
     if query == '-':
         result = subprocess.run(
-            command, 
+            command,
             input=fasta_data,
-            capture_output=True, 
-            text=True, 
+            capture_output=True,
+            text=True,
             check=True
         )
     else:
         result = subprocess.run(
-            command, 
-            capture_output=True, 
-            text=True, 
+            command,
+            capture_output=True,
+            text=True,
             check=True
         )
     return result.stdout, result.stderr


### PR DESCRIPTION
## Platform: x86_64-pc-linux-gnu, Ubuntu 22.04.5 LTS
## Tools: 
- Python 3.12
- MLST v2.33.0
- IsPcr v33
- Meningotype v0.8.6b
- BLAST v2.17.0

## Description of Issue:
1. Recently ran into issues with commands `meningotype --test --all` and `meningotype --updatedb`. 

The issue with `meningotype --test --all` stemmed back to run_blast.seqBLAST with the following error, where there are blastx calls in meningotype.py with parameters not accepted by seqBLAST:
>TypeError: seqBLAST() got an unexpected keyword argument 'seg'

Another seqBLAST() error exists as shown in #55 ; this issue stems around the use of double quotes in single quoted strings (e.g. outfmt="'6 qseqid sseqid pident length sstrand qstart qend sstart send slen'"). 

---

2. As for `meningotype --updatedb`, the primary issue stems from urlretrieve requiring a different import for python3. Two errors were thrown as shown below, one of which can be seen in #54:
```
Updating "/usr/local/lib/python3.12/site-packages/meningotype/db/PorA_VR1.fas" ...
Traceback (most recent call last):
File "/usr/local/lib/python3.12/site-packages/meningotype/meningotype.py", line 404, in main
update_db(porA1alleles, porA1URL)
File "/usr/local/lib/python3.12/site-packages/meningotype/meningotype.py", line 92, in update_db
urllib.urlretrieve(db_url, db_file)
^^^^^^^^^^^^^^^^^^
AttributeError: module 'urllib' has no attribute 'urlretrieve'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/usr/local/bin/meningotype", line 8, in <module>
sys.exit(main())
^^^^^^
File "/usr/local/lib/python3.12/site-packages/meningotype/meningotype.py", line 429, in main
except HTTPError:
^^^^^^^^^
NameError: name 'HTTPError' is not defined. Did you mean: 'TabError'?
```

---

3. Upon testing with conda, MLST ran into an issue where output was not coming out correctly.
```
meningotype --test --all
Running meningotype.py on test examples ...
$ meningotype.py A.fna B.fna C.fna W.fna X.fna Y.fna
SAMPLE_ID       SEROGROUP       ctrA    MLST    PorA    FetA    PorB    fHbp    NHBA    NadA    BAST
Traceback (most recent call last):
  File "/home/raheel138/miniconda3/envs/meningotype/bin/meningotype", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/meningotype.py", line 522, in main
    mlst = nm_mlst(f)
           ^^^^^^^^^^
  File "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/meningotype.py", line 177, in nm_mlst
    return PCRout.split('\t')[2]
           ~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Upon further investigation of trying MLST on the test files in meningotype, I ran into the following error:
```
mlst /mnt/c/Users/Rahee/OneDrive/Documents/meningotype/test/B.fna
Can't locate List/MoreUtils.pm in @INC (you may need to install the List::MoreUtils module) (@INC contains: /home/raheel138/miniconda3/envs/meningotype/lib/perl5/site_perl/5.22.2/x86_64-linux-thread-multi /home/raheel138/miniconda3/envs/meningotype/lib/perl5/site_perl/5.22.2 /home/raheel138/miniconda3/envs/meningotype/lib/perl5/5.22.2/x86_64-linux-thread-multi /home/raheel138/miniconda3/envs/meningotype/lib/perl5/5.22.2 .) at /home/raheel138/miniconda3/envs/meningotype/bin/mlst line 5.
BEGIN failed--compilation aborted at /home/raheel138/miniconda3/envs/meningotype/bin/mlst line 5.
```

## Attempted Fixes
1. I noticed some issues with the nm_mlst(), fineTYPE, and bxTYPE functions where they were not properly decoding the output from `proc = subprocess.Popen(['mlst', '--scheme=neisseria', '--quiet', f], stdout=subprocess.PIPE, stderr=subprocess.PIPE)`. I added a line to decode bytes to `proc.communicate()[0]` in all 3 functions, as done in seroTYPE().

See commit c0fd08a.

2. Updated meningotype.py to include proper import path for urllib.request.urlretrieve and HTTPError.

See commit 7402fba

3. Updated seqBLAST function to accept extra flags needed for usage in finetypeBLAST and bxtypeBLAST. Also edited all outfmt parameters to supply flags without additional quotation.

See commits 01e9a4f and f569cad.

4. I saw that ctrA_PCR() in ctrA.py was still using the deprecated NcbiblastnCommandline(). I replaced this with run_blast.seqBLAST().

See commit 4f118a6.

5. The fix I tried for issue 3 listed above was to run `conda install -c bioconda -c conda-forge perl-list-moreutils`. This led to the following package plan:

```
## Package Plan ##

  environment location: /home/raheel138/miniconda3/envs/meningotype

  added / updated specs:
    - perl-list-moreutils


The following NEW packages will be INSTALLED:

  perl-app-cpanminus bioconda/linux-64::perl-app-cpanminus-1.7043-pl5.22.0_0

The following packages will be UPDATED:

  ca-certificates    conda-forge/noarch::ca-certificates-2~ --> pkgs/main/linux-64::ca-certificates-2026.3.19-h06a4308_0
  perl-list-moreuti~                                0.413-1 --> 0.428-pl5.22.0_0

The following packages will be DOWNGRADED:

  perl                                           5.22.2.1-0 --> 5.22.0.1-0


Proceed ([y]/n)? y
```

Afterwards, I reran `meningotype --test --all`, and the test ran successfully.
```
Running meningotype.py on test examples ...
$ meningotype.py A.fna B.fna C.fna W.fna X.fna Y.fna
SAMPLE_ID       SEROGROUP       ctrA    MLST    PorA    FetA    PorB    fHbp    NHBA    NadA    BAST
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/A.fna A       ctrA    4      7,13-1                                                                                                               F1-5     NEIS2020_28     5       29      0       639
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/B.fna B       ctrA    8      5-2,10-1                                                                                                             F3-6     NEIS2020_12     16      20      8       150
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/C.fna C       ctrA    177    21,26-2                                                                                                              F1-5     NEIS2020_3      17      101     9       118
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/W.fna W       ctrA    11     5,new                                                                                                                F1-1     NEIS2020_244    623     29      6       -
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/X.fna X       ctrA    181    5-1,10-1                                                                                                             F4-23    NEIS2020_509    391     358     0       3042
/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/test/Y.fna Y       ctrA    23     5-2,10-1                                                                                                             F4-1     NEIS2020_67     25      7       0       228
```

After the aforementioned attempted fixes, `meningotype updatedb` ran successfully as well.
```
meningotype --updatedb
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/PorA_VR1.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/PorA_VR2.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/FetA_VR.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/PorB.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/fHbp_peptide.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/NHBA_peptide.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/NadA_peptide.fas" ...
Updating "/home/raheel138/miniconda3/envs/meningotype/lib/python3.12/site-packages/meningotype/db/BASTalleles.txt" ...
```

I included commit ff7f40e as a reference for the package name I installed for the fix, but I'm not sure how to resolve the package dependencies here; I believe that's part of the deployment to bioconda.